### PR TITLE
Default language locale file is used if the correct one is unavailable

### DIFF
--- a/Models/LanguageHandler.php
+++ b/Models/LanguageHandler.php
@@ -9,7 +9,7 @@ namespace Flashpoint\Models;
 class LanguageHandler
 {
 
-    private const DEFAULT_LANGUAGE = 'en-US';
+    public const DEFAULT_LANGUAGE = 'en-US';
     public const AVAILABLE_LANGUAGES = array(
         'de-DE' => 'Deutsch',
         'en-US' => 'English',

--- a/Models/Translator.php
+++ b/Models/Translator.php
@@ -11,6 +11,7 @@ class Translator
 
     /**
      * Method loading all required translations into a static variable
+     * If a locale file for the chosen language doesn't exist, an equivalent locale file in the default language is loaded
      * @param string $languageCode Code of the language whose translations are needed
      * @param array $dictionaries Filenames (without extensions) of the dictionary files containing the translations
      * @return bool TRUE, if the loaded static dictionary variable is not empty after loading everything, FALSE otherwise
@@ -18,9 +19,14 @@ class Translator
     public static function loadDictionaries(string $languageCode, array $dictionaries): bool
     {
         foreach ($dictionaries as $dictionary) {
+            $dictFilename = 'locales/'.$languageCode.'/'.$dictionary.'.json';
+            if (!file_exists($dictFilename)) {
+                $dictFilename = 'locales/'.LanguageHandler::DEFAULT_LANGUAGE.'/'.$dictionary.'.json';
+            }
+
             self::$dictionary = array_merge(
                 self::$dictionary,
-                json_decode(file_get_contents('locales/'.$languageCode.'/'.$dictionary.'.json'), true)
+                json_decode(file_get_contents($dictFilename), true)
             );
         }
         return empty(self::$dictionary);

--- a/Models/Translator.php
+++ b/Models/Translator.php
@@ -8,27 +8,42 @@ class Translator
 
     private const TRANSLATION_FILE_PATH = 'locales/{locale}.json';
     private static array $dictionary = array();
+    private static array $fallbackDictionary = array();
 
     /**
      * Method loading all required translations into a static variable
      * If a locale file for the chosen language doesn't exist, an equivalent locale file in the default language is loaded
      * @param string $languageCode Code of the language whose translations are needed
      * @param array $dictionaries Filenames (without extensions) of the dictionary files containing the translations
+     * @param bool $fallbackStrings TRUE, if the strings should be loaded into a fallback dictionary instead of the primary one; default FALSE
      * @return bool TRUE, if the loaded static dictionary variable is not empty after loading everything, FALSE otherwise
      */
-    public static function loadDictionaries(string $languageCode, array $dictionaries): bool
+    public static function loadDictionaries(string $languageCode, array $dictionaries, bool $fallbackStrings = false): bool
     {
         foreach ($dictionaries as $dictionary) {
             $dictFilename = 'locales/'.$languageCode.'/'.$dictionary.'.json';
             if (!file_exists($dictFilename)) {
-                $dictFilename = 'locales/'.LanguageHandler::DEFAULT_LANGUAGE.'/'.$dictionary.'.json';
+                continue;
             }
 
-            self::$dictionary = array_merge(
-                self::$dictionary,
-                json_decode(file_get_contents($dictFilename), true)
-            );
+            if ($fallbackStrings) {
+                self::$fallbackDictionary = array_merge(
+                    self::$fallbackDictionary,
+                    json_decode(file_get_contents($dictFilename), true)
+                );
+            } else {
+                self::$dictionary = array_merge(
+                    self::$dictionary,
+                    json_decode(file_get_contents($dictFilename), true)
+                );
+            }
         }
+
+        if ($languageCode !== LanguageHandler::DEFAULT_LANGUAGE) {
+            //Load the fallback dictionary (the default language)
+            self::loadDictionaries(LanguageHandler::DEFAULT_LANGUAGE, $dictionaries, true);
+        }
+
         return empty(self::$dictionary);
     }
 
@@ -41,7 +56,10 @@ class Translator
     {
         $markedString = @self::$dictionary[$key];
         if (empty($markedString)) {
-            return null;
+            $markedString = @self::$fallbackDictionary[$key];
+            if (empty($markedString)) {
+                return null;
+            }
         }
 
         if (empty($formatTags)) {


### PR DESCRIPTION
In case the locale file for the selected language doesn't exist, an equivalent locale file in the default language is used.

This way, at least English text will be displayed instead of nothing.