### PR TITLE
Fix of a 404 link

### DIFF
--- a/Views/error404.phtml
+++ b/Views/error404.phtml
@@ -2,4 +2,4 @@
 <hr class="title-divider">
 
 <p><?= t('Error_Para1') ?></p>
-<p><?= t('Error_Para2', '<a href="/contact">') ?></p>
+<p><?= t('Error_Para2', '<a href="contact">') ?></p>


### PR DESCRIPTION
I forgot that the homepage is not the root URL of the domain, but sits inside of `/flashpoint`

Whoever merges this, can you please make sure the change is deployed to production? I don't have a full FTP access.