### PR TITLE
Makes French language code consistent with other languages

### DIFF
--- a/locales/fr-FR/layout.json
+++ b/locales/fr-FR/layout.json
@@ -1,5 +1,5 @@
 {
-  "Lang_Code": "fr",
+  "Lang_Code": "fr-FR",
   "Home": "Accueil",
   "Platforms": "Plateformes",
   "News": "Actualités",


### PR DESCRIPTION
Should also fix the French "Download Flashpoint" graphic, which still doesn't appear on the website due to it using the "fr-FR" naming. (My first pull request, hopefully I did this right lol.)